### PR TITLE
Update database utility scripts

### DIFF
--- a/utils/database/comments/addComment.js
+++ b/utils/database/comments/addComment.js
@@ -1,5 +1,10 @@
 const path = require("path");
-const { db } = require(path.resolve(__dirname, "./../connectTestDatabase"));
+const db = require(path.resolve(
+	__dirname,
+	"./../../../models/connectUtilsTestDatabase.js"
+))();
+
+console.log("Adding a sample comment to the database");
 
 const Comment = require(path.resolve(__dirname, "./../../../models/comment"));
 

--- a/utils/database/comments/addReply.js
+++ b/utils/database/comments/addReply.js
@@ -1,6 +1,8 @@
 const path = require("path");
-const { db } = require(path.resolve(__dirname, "./../connectTestDatabase"));
-
+const db = require(path.resolve(
+	__dirname,
+	"./../../../models/connectUtilsTestDatabase.js"
+))();
 const Comment = require(path.resolve(__dirname, "./../../../models/comment"));
 
 const statement = db.prepare(Comment.newComment());

--- a/utils/database/comments/getAllComments.js
+++ b/utils/database/comments/getAllComments.js
@@ -1,14 +1,9 @@
 const path = require("path");
-const sqlite3 = require("sqlite3").verbose();
-const db = new sqlite3.Database(
-	path.resolve(__dirname, "./../test-database.sqlite"),
-	(err) => {
-		if (err) {
-			console.log(err);
-		}
-	}
-);
 
+const db = require(path.resolve(
+	__dirname,
+	"./../../../models/connectUtilsTestDatabase.js"
+))();
 const Comment = require("./../../../models/comment");
 
 db.all(Comment.getAllComments(), (err, rows) => {

--- a/utils/database/comments/populateComments.js
+++ b/utils/database/comments/populateComments.js
@@ -1,6 +1,8 @@
 const path = require("path");
-const { db } = require(path.resolve(__dirname, "./../connectTestDatabase"));
-
+const db = require(path.resolve(
+	__dirname,
+	"./../../../models/connectUtilsTestDatabase.js"
+))();
 const Comment = require("./../../../models/comment");
 
 const statement = db.prepare(Comment.newComment());

--- a/utils/database/createUtilsTables.js
+++ b/utils/database/createUtilsTables.js
@@ -1,8 +1,11 @@
 const path = require("path");
-const { db } = require(path.resolve(__dirname, "./connectTestDatabase"));
 
-const Comment = require("./../../models/comment");
-const User = require("./../../models/user");
+const db = require(path.resolve(
+	__dirname,
+	"./../../models/connectUtilsTestDatabase"
+))();
+const Comment = require("../../models/comment");
+const User = require("../../models/user");
 
 db.serialize(() => {
 	db.run(Comment.dropCommentsTable());

--- a/utils/database/viewAllUtilsTables.js
+++ b/utils/database/viewAllUtilsTables.js
@@ -1,13 +1,8 @@
-const sqlite3 = require("sqlite3").verbose();
 const path = require("path");
-const db = new sqlite3.Database(
-	path.resolve(__dirname, "./test-database.sqlite"),
-	(err) => {
-		if (err) {
-			console.log(err);
-		}
-	}
-);
+const db = require(path.resolve(
+	__dirname,
+	"./../../models/connectUtilsTestDatabase"
+))();
 
 db.all(`SELECT * FROM users`, (err, rows) => {
 	if (err) {


### PR DESCRIPTION
Now that the new module `connectUtilsTestDatabase` directly exports `db`:
- Update the way utility scripts use `require` to import it.