### PR TITLE
Add `POST /api/comments` test

### DIFF
--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -96,8 +96,7 @@ describe.only('POST "/api/comments"', () => {
 		replyingToUser: 1,
 	};
 	const VALID_NEW_COMMENT_REQUIRED_FIELDS = {
-		content:
-			"Added by the 'Return the added comment' test. Provides only required fields in the body.",
+		content: "A new comment without optional fields.",
 		user: 1,
 	};
 
@@ -162,7 +161,7 @@ describe.only('POST "/api/comments"', () => {
 	test("When optional values are not provided, they return the correct default value", async () => {
 		const response = await api
 			.post(API_URL)
-			.send(VALID_NEW_COMMENT_REQUIRED_FIELDS)
+			.send({ newComment: VALID_NEW_COMMENT_REQUIRED_FIELDS })
 			.expect(201)
 			.expect("Content-Type", /application\/json/);
 

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -172,7 +172,7 @@ describe.only('POST "/api/comments"', () => {
 	test("Return an error response when the content is missing", async () => {
 		const response = await api
 			.post(API_URL)
-			.send({ ...VALID_NEW_COMMENT_ALL_FIELDS, content: null })
+			.send({ newComment: { ...VALID_NEW_COMMENT_ALL_FIELDS, content: null } })
 			.expect(400)
 			.expect("Content-Type", /application\/json/);
 		expect(response.body.error).toBe("Missing required field(s).");

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -90,9 +90,8 @@ describe.only('POST "/api/comments"', () => {
 	});
 
 	const VALID_NEW_COMMENT_ALL_FIELDS = {
-		content:
-			"Added by the 'Return the added comment' test. Provides all fields in the body",
-		user: 1,
+		content: "A new comment with all fields.",
+		user: 2,
 		replyingToComment: 1,
 		replyingToUser: 1,
 	};
@@ -103,9 +102,14 @@ describe.only('POST "/api/comments"', () => {
 	};
 
 	test("Return the correct response when a comment with all fields is added.", async () => {
+		const sampleState = [{ id: 1, content: "Comment in the state.", user: 1 }];
+
 		const response = await api
 			.post(API_URL)
-			.send(VALID_NEW_COMMENT_ALL_FIELDS)
+			.send({
+				allComments: sampleState,
+				newComment: VALID_NEW_COMMENT_ALL_FIELDS,
+			})
 			.expect(201)
 			.expect("Content-Type", /application\/json/);
 

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -124,7 +124,7 @@ describe.only('POST "/api/comments"', () => {
 		);
 	});
 
-	test.only("Returns the correct value for replyingToComment.", async () => {
+	test("Returns the correct value for replyingToComment.", async () => {
 		const DATA = [
 			{
 				id: 1,

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -121,6 +121,40 @@ describe.only('POST "/api/comments"', () => {
 		);
 	});
 
+	test.only("Returns the correct value for replyingToComment.", async () => {
+		const DATA = [
+			{
+				id: 1,
+				content: "first comment",
+				user: 1,
+			},
+			{
+				id: 2,
+				content: "second comment",
+				user: 2,
+				replyingToComment: 1,
+				replyingToUser: 1,
+			},
+		];
+
+		const response = await api
+			.post(API_URL)
+			.send({
+				allComments: DATA,
+				newComment: {
+					content: "Replies to comment 2, but its root comment's id is 1.",
+					user: 1,
+					replyingToComment: 2,
+					replyingToUser: 2,
+				},
+			})
+			.expect(201)
+			.expect("Content-Type", /application\/json/);
+
+		expect(response.body.replyingToComment).toBe(1);
+		expect(response.body.replyingToUser).toBe(2);
+	});
+
 	test("When optional values are not provided, they return the correct default value", async () => {
 		const response = await api
 			.post(API_URL)


### PR DESCRIPTION
- Add test: the server sets the `replyingToComment` value properly. 

This new test will result in changes in `CommentsController` implementation.
- `POST` requests must now provide a `newComment` object.
  - When the new comment (`newComment`) is a reply, the request body must also include an `allComments` (the Redux state) array.

Other tests are also updated to query the router with the required fields (`newComment` and `allComments`).