### PR TITLE
Define new paths for separate controllers

### DIFF
--- a/controllers/comments.routes.js
+++ b/controllers/comments.routes.js
@@ -6,7 +6,16 @@ const CommentController = require("./comments.controllers");
  * Add a new comment
  */
 CommentsRouter.post(
-	"/",
+	"/newComment",
+	CommentController.checkMissingContent,
+	CommentController.insertComment,
+	(req, res) => {
+		res.status(201).json(req.body.newComment);
+	}
+);
+
+CommentsRouter.post(
+	"/newReply",
 	CommentController.checkMissingContent,
 	CommentController.insertComment,
 	CommentController.setRootComment,


### PR DESCRIPTION
- Apply `setRootComment` middleware only for the `/newReply` path.

Fixes #34 