### PR TITLE
Remove `trimContent`

### DIFF
--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -9,7 +9,7 @@ const xss = require("xss");
 const helper = require("./../utils/helper");
 
 /**
- * Checks the content property is defined in a request body.
+ * Checks the new comment or reply has a defined content property.
  */
 function checkMissingContent(req, res, next) {
 	if (!req.body.newComment.content) {

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -21,22 +21,6 @@ function checkMissingContent(req, res, next) {
 }
 
 /**
- * Checks the content property is defined in a request body.
- */
-function checkEmptyReply(req, res, next) {
-	try {
-		if (!req.body.newComment.content.length) {
-			const err = new Error();
-			err.name = "MissingRequiredField";
-			next(err);
-		}
-		next();
-	} catch (error) {
-		next(error);
-	}
-}
-
-/**
  * Sanitizes input and inserts a comment in the database.
  */
 async function insertComment(req, res, next) {
@@ -110,7 +94,6 @@ async function findCurrentUserVotes(req, res, next) {
 }
 
 module.exports = {
-	checkEmptyReply,
 	checkMissingContent,
 	insertComment,
 	setRootComment,

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -25,17 +25,11 @@ function checkMissingContent(req, res, next) {
  */
 function checkEmptyReply(req, res, next) {
 	try {
-		const trimmedContent = helper.trimContent(
-			req.body.newComment.replyingToAuthor,
-			req.body.newComment.content
-		);
-
-		if (!trimmedContent) {
+		if (!req.body.newComment.content.length) {
 			const err = new Error();
 			err.name = "MissingRequiredField";
 			next(err);
 		}
-		req.body.newComment.content = trimmedContent;
 		next();
 	} catch (error) {
 		next(error);

--- a/controllers/comments.routes.js
+++ b/controllers/comments.routes.js
@@ -23,7 +23,7 @@ CommentsRouter.post(
 
 CommentsRouter.post(
 	"/newReply",
-	CommentController.checkEmptyReply,
+	CommentController.checkMissingContent,
 	CommentController.insertComment,
 	CommentController.setRootComment,
 	(req, res) => {

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -20,7 +20,7 @@ describe('GET "/api/comments"', () => {
 		db.run(`DELETE FROM comments;`);
 	});
 
-	test.only("Returns all comments in the database", async () => {
+	test("Returns all comments in the database", async () => {
 		const DATA = [
 			{
 				user: 1,
@@ -63,7 +63,7 @@ describe('GET "/api/comments"', () => {
 		expect(response.body[0].replyingToUser).toBe(DATA[0].replyingToUser);
 	});
 
-	test.only("Replies are correctly included in the array of their root comment", async () => {
+	test("Replies are correctly included in the array of their root comment", async () => {
 		const ROOT_COMMENT_CONTENT = "This is the root comment";
 		const DATA = [
 			{
@@ -161,7 +161,7 @@ describe('POST "/api/comments/newReply"', () => {
 		db.run(`DELETE FROM comments;`);
 	});
 
-	test("Returns the correct information on the comment getting replied to .", async () => {
+	test.only("Returns the correct information on the comment getting replied to.", async () => {
 		const DATA = [
 			{
 				id: 1,
@@ -185,21 +185,24 @@ describe('POST "/api/comments/newReply"', () => {
 			},
 		];
 
+		const newReply = {
+			content: "Replies to comment 2, but its root comment's id is 1.",
+			user: 1,
+			replyingToComment: 2,
+			replyingToUser: 2,
+			replyingToAuthor: "@username ",
+		};
+
 		const response = await api
 			.post(ROUTE)
 			.send({
 				allComments: DATA,
-				newComment: {
-					content: "Replies to comment 2, but its root comment's id is 1.",
-					user: 1,
-					replyingToComment: 2,
-					replyingToUser: 2,
-					replyingToAuthor: "@username ",
-				},
+				newComment: { ...newReply },
 			})
 			.expect(201)
 			.expect("Content-Type", /application\/json/);
 
+		expect(response.body.content).toBe(newReply.content);
 		expect(response.body.replyingToComment).toBe(1);
 		expect(response.body.replyingToUser).toBe(2);
 	});

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -20,15 +20,6 @@ function findAllReplies(allComments) {
 }
 
 /**
- * Trims the comment to only keep the actual content. Avoids duplicated "@username "
- */
-function trimContent(username, content) {
-	const usernameLength = username.length + 2;
-	const trimContent = content.substring(usernameLength, content.length);
-	return trimContent;
-}
-
-/**
  * Uses recursion to find the root comment of a reply.
  */
 const findRootComment = function (allComments, currentCommentID) {
@@ -48,6 +39,5 @@ const findRootComment = function (allComments, currentCommentID) {
 
 module.exports = {
 	findRootComment,
-	trimContent,
 	findAllReplies,
 };


### PR DESCRIPTION
- Improve test for new replies
  -   Assert the content of the new reply is properly saved and returned in the response.
- Remove `checkEmptyReply`, replaced with `checkMissingContent`

Fixes #43