### PR TITLE
Fix `createdAt` tests, format date

### DIFF
--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,7 +1,7 @@
 const path = require("path");
 
 // Modules interacting with the database
-const CommentModel = require(path.resolve(__dirname, "./../models/comment"));
+const CommentModel = require(path.resolve(__dirname, "./../models/Comment"));
 
 // Strips dangerous characters from data sent by clients.
 const xss = require("xss");
@@ -37,7 +37,6 @@ async function insertComment(req, res, next) {
 	CommentModel.insertOne([
 		newComment.user,
 		newComment.content,
-		newComment.createdAt,
 		newComment.score,
 		newComment.replyingToComment,
 		newComment.replyingToUser,

--- a/models/comment.js
+++ b/models/comment.js
@@ -26,7 +26,7 @@ const CREATE_COMMENT_VOTES_TABLE_QUERY = `CREATE TABLE comment_votes(
 /**
  * Add a new comment
  */
-const NEW_COMMENT_QUERY = `INSERT INTO comments (user, content, createdAt, score,  replyingToComment, replyingToUser) VALUES (?, ?, ?, ?, ?, ?)`;
+const NEW_COMMENT_QUERY = `INSERT INTO comments (user, content, createdAt, score,  replyingToComment, replyingToUser) VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?, ?)`;
 
 /**
  *  Get all comments

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -26,7 +26,6 @@ describe('GET "/api/comments"', () => {
 				user: 1,
 				content:
 					"Impressive! Though it seems the drag feature could be improved. But overall it looks incredible. You've nailed the design and the responsiveness at various breakpoints works really well.",
-				createdAt: new Date(),
 				score: 12,
 				replyingToUser: null,
 				replyingToComment: null,
@@ -38,7 +37,6 @@ describe('GET "/api/comments"', () => {
 				const addedComment = await Comment.insertOne([
 					comment.user,
 					comment.content,
-					comment.createdAt,
 					comment.score,
 					comment.replyingToComment,
 					comment.replyingToUser,
@@ -69,7 +67,6 @@ describe('GET "/api/comments"', () => {
 			{
 				user: 1,
 				content: ROOT_COMMENT_CONTENT,
-				createdAt: new Date(),
 				score: 12,
 				replyingToUser: null,
 				replyingToComment: null,
@@ -77,7 +74,6 @@ describe('GET "/api/comments"', () => {
 			{
 				user: 2,
 				content: "This is the reply",
-				createdAt: new Date(),
 				score: 5,
 				replyingToUser: 0,
 				replyingToComment: 1,
@@ -89,7 +85,6 @@ describe('GET "/api/comments"', () => {
 				const addedComment = await Comment.insertOne([
 					comment.user,
 					comment.content,
-					comment.createdAt,
 					comment.score,
 					comment.replyingToComment,
 					comment.replyingToUser,
@@ -166,7 +161,6 @@ describe('POST "/api/comments/newReply"', () => {
 			{
 				id: 1,
 				content: "first comment",
-				createdAt: new Date(),
 				score: 12,
 				user: 1,
 				replies: [],
@@ -177,7 +171,6 @@ describe('POST "/api/comments/newReply"', () => {
 				id: 2,
 				content: "second comment",
 				user: 2,
-				createdAt: new Date(),
 				score: 9,
 				replies: [],
 				replyingToComment: 1,

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -156,7 +156,7 @@ describe('POST "/api/comments/newReply"', () => {
 		db.run(`DELETE FROM comments;`);
 	});
 
-	test.only("Returns the correct information on the comment getting replied to.", async () => {
+	test("Returns the correct information on the comment getting replied to.", async () => {
 		const DATA = [
 			{
 				id: 1,

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -52,8 +52,10 @@ describe('GET "/api/comments"', () => {
 		expect(response.body[0].user).toBe(1);
 		expect(response.body[0].user).toBe(DATA[0].user);
 		expect(response.body[0].content).toBe(DATA[0].content);
-		expect(spy).toHaveBeenCalled();
 		expect(response.body[0].score).toBe(DATA[0].score);
+		expect(response.body[0].createdAt).toBeDefined();
+		expect(response.body[0].createdAt instanceof Date && !isNaN(date.valueOf()))
+			.toBeTrue;
 		expect(response.body[0].replyingToComment).toBe(DATA[0].replyingToComment);
 		expect(response.body[0].replyingToUser).toBe(DATA[0].replyingToUser);
 	});
@@ -130,7 +132,8 @@ describe('POST "/api/comments/newComment"', () => {
 		expect(response.body.content).toEqual(VALID_NEW_COMMENT.content);
 		expect(response.body.user).toEqual(VALID_NEW_COMMENT.user);
 		expect(response.body.createdAt).toBeDefined();
-		expect(spy).toHaveBeenCalled(); // Check new Date() was called. createdAt will evaluate to '[object Object]' in the database, and mockConstructor {} in the response body. Which is normal because the Date constructor is being mocked.
+		expect(response.body.createdAt instanceof Date && !isNaN(date.valueOf()))
+			.toBeTrue;
 		expect(response.body.replyingToComment).toBeNull();
 		expect(response.body.replyingToUser).toBeNull();
 	});

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -12,9 +12,6 @@ const Comment = require(path.resolve(__dirname, "./../models/comment"));
 
 const API_URL = "/api/comments";
 
-// Mock the Date object. Will be used to check an instance of Date was created
-const spy = jest.spyOn(global, "Date");
-
 describe('GET "/api/comments"', () => {
 	afterEach(() => {
 		db.run(`DELETE FROM comments;`);

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -1,4 +1,27 @@
 /**
+ * Formats the date in a relative format.
+ */
+function formatDate(date) {
+	const timestamp = new Date(date).getTime();
+	const relative = new Intl.RelativeTimeFormat("en-GB", { numeric: "auto" });
+	const then = Math.floor(new Date(timestamp));
+	const now = new Date();
+	const days = (then - now) / 86400000;
+	const getRelativeDate = (formatUnit, unitInDays = 1) =>
+		relative.format(Math.trunc(days / unitInDays), formatUnit);
+
+	if (days <= -365) {
+		return getRelativeDate("year", -365);
+	} else if (days <= -30) {
+		return getRelativeDate("month", -30);
+	} else if (days <= -7) {
+		return getRelativeDate("week", -7);
+	} else if (days > -7) {
+		return getRelativeDate("days");
+	}
+}
+
+/**
  * Adds a replies array to all comments. Then populates the same array with the id keys of received replies.
  */
 function findAllReplies(allComments) {
@@ -38,6 +61,7 @@ const findRootComment = function (allComments, currentCommentID) {
 };
 
 module.exports = {
+	formatDate,
 	findRootComment,
 	findAllReplies,
 };


### PR DESCRIPTION
- Stop mocking the `Date` object in tests, instead the `createdAt` value from the response is validated with the `Date` constructor.
- Format the date with the `helper.formatDate` moved from the frontend.
- Generate the timestamp at which a comment is added using a SQL query.
  - The `newComment.createdAt` is still temporarily used in the `insertComment` controller to have a value the frontend can use before the next rerender.

Fixes #44
Fixes #46