### PR TITLE
Format the date in `POST /api/comments/newComment` responses.

### DIFF
--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -42,7 +42,11 @@ async function insertComment(req, res, next) {
 		newComment.replyingToUser,
 	])
 		.then((newCommentID) => {
-			req.body.newComment = { id: newCommentID, ...newComment };
+			req.body.newComment = {
+				...newComment,
+				id: newCommentID,
+				createdAt: helper.formatDate(newComment.createdAt),
+			};
 			next();
 		})
 		.catch((error) => {


### PR DESCRIPTION
Fixes #44